### PR TITLE
Set default value for StartGroupNumber

### DIFF
--- a/airtouch4pyapi/airtouch.py
+++ b/airtouch4pyapi/airtouch.py
@@ -78,6 +78,7 @@ class AirTouch:
         self.acs = dict();
         self.groups = dict();
         self.Messages:List[AirTouchError] = [];
+        self.StartGroupNumber = 0
     
     async def UpdateInfo(self):
         if(self.atPort != None and self.atVersion == None):


### PR DESCRIPTION
Partial resolution for https://github.com/LonePurpleWolf/airtouch4pyapi/issues/22

I'm not really sure what StartGroupNumber actually means, but I suspect based on the way the code treats it that 0 is the normal value for it that the vast majority of people will see.